### PR TITLE
Call yum/apt in xterm to update template (#982)

### DIFF
--- a/qubesmanager/main.py
+++ b/qubesmanager/main.py
@@ -1373,9 +1373,15 @@ class VmManagerWindow(Ui_VmManagerWindow, QMainWindow):
                     'autostart': True,
                     'notify_function': lambda lvl, msg: trayIcon
                     .showMessage(msg, msecs=3000)}
-                vm.run("yum clean expire-cache", user='root', wait=True,
-                       **vm_run_common_args)
-                vm.run("gpk-update-viewer;service qubes-update-check start -P",
+                # workaround for broken packagekit (#982)
+                update_command = "if [ -f /etc/fedora-release ]; then " \
+                                 "yum update; " \
+                                 "else " \
+                                 "apt-get update && apt-get -V dist-upgrade;" \
+                                 "fi"
+                vm.run("xterm -e sudo sh -c '{}';"
+                       "sudo service qubes-update-check start".
+                       format(update_command),
                        **vm_run_common_args)
         except Exception as ex:
             thread_monitor.set_error_msg(str(ex))


### PR DESCRIPTION
Since GUI updaters are broken, workaround this by starting terminal
update in xterm. Not an ideal option, but the proper solution seems to
be much more complicated:
https://phabricator.whonix.org/T373
QubesOS/qubes-issues#1197
QubesOS/qubes-issues#982