### PR TITLE
Qubes VM Manager drop down menu strings consistency fixes

### DIFF
--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -389,10 +389,10 @@
      <normaloff>:/createvm.png</normaloff>:/createvm.png</iconset>
    </property>
    <property name="text">
-    <string>Create AppVM</string>
+    <string>Create VM</string>
    </property>
    <property name="toolTip">
-    <string>Create a new AppVM</string>
+    <string>Create a new VM</string>
    </property>
   </action>
   <action name="action_removevm">
@@ -404,10 +404,10 @@
      <normaloff>:/removevm.png</normaloff>:/removevm.png</iconset>
    </property>
    <property name="text">
-    <string>Remove AppVM</string>
+    <string>Remove VM</string>
    </property>
    <property name="toolTip">
-    <string>Remove an existing AppVM (must be stopped first)</string>
+    <string>Remove an existing VM (must be stopped first)</string>
    </property>
   </action>
   <action name="action_resumevm">


### PR DESCRIPTION
Currently:
* Create AppVM
* Remove AppVM
* Clone VM
* Start/Resume VM
* [...] VM

The first two are inconsistent. @bnvk and I agreed, that those should be changed AppVM -> VM for consistency.

And I add, if anything, it would have to be "Create TemplateBased-VM". Because currently, if you click "Create AppVM", you are asked in the next wizard if you wanted to create an AppVM, NetVM or ProxyVM. So the term AppVM is overloaded.

This commit fixes this.